### PR TITLE
Fix GitHub language detection to show C# instead of HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
-
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
@@ -11,7 +10,6 @@
 # Note: This is only used by command line
 ###############################################################################
 #*.cs     diff=csharp
-
 ###############################################################################
 # Set the merge driver for project and solution files
 #
@@ -34,7 +32,6 @@
 #*.modelproj merge=binary
 #*.sqlproj   merge=binary
 #*.wwaproj   merge=binary
-
 ###############################################################################
 # behavior for image files
 #
@@ -43,7 +40,6 @@
 #*.jpg   binary
 #*.png   binary
 #*.gif   binary
-
 ###############################################################################
 # diff behavior for common document formats
 # 
@@ -61,3 +57,28 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# GitHub Linguist Configuration
+# 
+# Override repository language detection to properly show this as a C# project
+# since Blazor Developer Tools is primarily for .NET/C# developers
+###############################################################################
+* linguist-language=C#
+
+# Still properly identify specific file types for syntax highlighting
+*.html linguist-language=HTML
+*.css linguist-language=CSS
+*.js linguist-language=JavaScript
+*.ts linguist-language=TypeScript
+*.json linguist-language=JSON
+*.xml linguist-language=XML
+*.md linguist-language=Markdown
+*.yml linguist-language=YAML
+*.yaml linguist-language=YAML
+
+# Ensure Blazor and C# files are properly recognized
+*.cs linguist-language=C#
+*.razor linguist-language=C#
+*.cshtml linguist-language=C#
+*.csproj linguist-language=XML

--- a/BlazorDeveloperTools.sln
+++ b/BlazorDeveloperTools.sln
@@ -15,6 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorDeveloperTools.Tasks"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		NuGet.config = NuGet.config
 		README.md = README.md


### PR DESCRIPTION
## Description
   This PR updates the .gitattributes file to properly identify Blazor Developer Tools as a C#/.NET project rather than an HTML project.

   ## Problem
   - GitHub's Linguist was incorrectly detecting the repository as primarily HTML
   - This was misleading for developers discovering the project, as it's fundamentally a .NET/C# tool
   - The NuGet package is the heart of the project, with browser extensions and demo projects as supporting infrastructure

   ## Solution
   - Added Linguist configuration to override default language detection
   - Set repository default language to C# while preserving proper syntax highlighting for individual file types
   - Explicitly marked Blazor and Razor files as C# language

   ## Impact
   - Repository will now correctly show as 'C#' in GitHub profile pins and language statistics
   - Better discovery for .NET developers looking for Blazor tooling
   - More accurate representation of the project's technology stack

   ## Testing
   - Changes will take effect after merge when GitHub reprocesses the repository
   - No functional code changes, only metadata for GitHub's language detection