### PR TITLE
Release: extension 1.0.0-beta.3 + NuGet 1.0.0-beta.6

### DIFF
--- a/BlazorDevTools.Docs.Site.Server/BlazorDevTools.Docs.Site.Server.csproj
+++ b/BlazorDevTools.Docs.Site.Server/BlazorDevTools.Docs.Site.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorDeveloperTools" Version="1.0.0-beta.5" />
+    <PackageReference Include="BlazorDeveloperTools" Version="1.0.0-beta.6" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorDeveloperTools/BlazorDeveloperTools.csproj
+++ b/src/BlazorDeveloperTools/BlazorDeveloperTools.csproj
@@ -13,8 +13,8 @@
 
 		<!-- Package Identity -->
 		<PackageId>BlazorDeveloperTools</PackageId>
-		<Version>1.0.0-beta.5</Version>
-		<PackageVersion>1.0.0-beta.5</PackageVersion>
+		<Version>1.0.0-beta.6</Version>
+		<PackageVersion>1.0.0-beta.6</PackageVersion>
 		<Authors>Joseph E. Gregory</Authors>
 		<Description>Developer tools for Blazor applications. Provides component lifecycle tracking, performance metrics, and real-time debugging capabilities.</Description>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/browser-extensions/package.json
+++ b/src/browser-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blazor-developer-tools",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Browser developer tools for Blazor applications",
   "scripts": {
     "build": "webpack --mode production",


### PR DESCRIPTION
Version bumps for the coordinated release:

- **Extension → 1.0.0-beta.3** (manifests stamped 1.0.0.3 from package.json): timeline overhaul — sequence/subway view, smooth zoom/pan, reliable event selection (#47), disconnect handling. Store zips built from this branch.
- **NuGet → 1.0.0-beta.6** (already pushed to nuget.org): componentId-always-0 fix, concurrent-enumeration retry (#34).
- **Docs site → references beta.6**; the version badge updates automatically.

⚠️ Merge after nuget.org finishes indexing beta.6 (~5-15 min after push), since the Azure site deploy must restore it.