### PR TITLE
Timeline: Batches view — one bar per render batch

### DIFF
--- a/src/browser-extensions/src/core/commits.ts
+++ b/src/browser-extensions/src/core/commits.ts
@@ -1,0 +1,117 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLAZOR DEVELOPER TOOLS - commits.ts
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Commit derivation for the React-DevTools-style profiler view: one "commit"
+// per burst of rendering work, so a recording reads as a series of discrete
+// updates rather than a soup of events.
+//
+// The NuGet package's render-batch recording (TimelineRecorder.RecordBatchStart)
+// is not wired to the Renderer yet, so events carry no usable BatchId. Instead
+// commits are derived CLIENT-SIDE by time-clustering: consecutive events whose
+// start lies within GAP_MS of the cluster's end belong to the same commit.
+// Blazor completes a render batch in single-digit milliseconds while distinct
+// user interactions are spaced by 100ms+, so a small gap threshold separates
+// them cleanly. When real BatchIds land in a future package, this module can
+// prefer them and keep clustering as the fallback.
+//
+// Pure logic — no DOM — for unit testing.
+//
+// ═══════════════════════════════════════════════════════════════════════════════
+
+import type { TimelineEvent } from './types';
+
+/** Events that represent actual render work (a component producing output). */
+const RENDER_EVENT_TYPES = new Set(['BuildRenderTree', 'ComponentRendered']);
+
+/** New commit when the next event starts more than this after the cluster end. */
+export const COMMIT_GAP_MS = 50;
+
+export interface CommitComponent {
+    componentId: number;
+    componentName: string;
+    /** Sum of BuildRenderTree durations for this component in the commit. */
+    durationMs: number;
+    /** Number of render events for this component in the commit. */
+    renderCount: number;
+    /** Event id of the component's first render event (for selection). */
+    firstEventId: number;
+}
+
+export interface Commit {
+    /** 0-based position in the recording. */
+    index: number;
+    startMs: number;
+    endMs: number;
+    /** Sum of all BuildRenderTree durations in the commit. */
+    totalRenderMs: number;
+    /** Number of render events in the commit. */
+    renderCount: number;
+    /** Per-component breakdown, slowest first. */
+    components: CommitComponent[];
+    /** Every event in the cluster (renders and lifecycle alike). */
+    events: TimelineEvent[];
+}
+
+/**
+ * Cluster a recording's events into commits. Clusters containing no render
+ * work (only lifecycle noise) are dropped — commits are about output.
+ */
+export function deriveCommits(events: TimelineEvent[], gapMs: number = COMMIT_GAP_MS): Commit[] {
+    if (events.length === 0) return [];
+
+    const sorted = [...events].sort((a, b) => a.relativeTimestampMs - b.relativeTimestampMs);
+
+    interface Cluster { events: TimelineEvent[]; endMs: number; }
+    const clusters: Cluster[] = [];
+    let current: Cluster | null = null;
+
+    for (const e of sorted) {
+        const start = e.relativeTimestampMs;
+        const end = start + (e.durationMs || 0);
+        if (!current || start - current.endMs > gapMs) {
+            current = { events: [], endMs: end };
+            clusters.push(current);
+        }
+        current.events.push(e);
+        current.endMs = Math.max(current.endMs, end);
+    }
+
+    const commits: Commit[] = [];
+    for (const cluster of clusters) {
+        const renderEvents = cluster.events.filter(e => RENDER_EVENT_TYPES.has(e.eventType));
+        if (renderEvents.length === 0) continue; // lifecycle-only noise
+
+        const byComponent = new Map<number, CommitComponent>();
+        for (const e of renderEvents) {
+            let entry = byComponent.get(e.componentId);
+            if (!entry) {
+                entry = {
+                    componentId: e.componentId,
+                    componentName: e.componentName,
+                    durationMs: 0,
+                    renderCount: 0,
+                    firstEventId: e.eventId,
+                };
+                byComponent.set(e.componentId, entry);
+            }
+            entry.renderCount++;
+            entry.durationMs += e.durationMs || 0;
+        }
+
+        const components = Array.from(byComponent.values())
+            .sort((a, b) => b.durationMs - a.durationMs);
+
+        commits.push({
+            index: commits.length,
+            startMs: cluster.events[0].relativeTimestampMs,
+            endMs: cluster.endMs,
+            totalRenderMs: components.reduce((sum, c) => sum + c.durationMs, 0),
+            renderCount: renderEvents.length,
+            components,
+            events: cluster.events,
+        });
+    }
+
+    return commits;
+}

--- a/src/browser-extensions/src/core/timeline-panel.ts
+++ b/src/browser-extensions/src/core/timeline-panel.ts
@@ -24,6 +24,7 @@ import type {
     ComponentRanking,
 } from './types';
 import { buildTimeScale, buildSequenceScale, type TimeScale, type TimeInterval } from './time-scale';
+import { deriveCommits, type Commit } from './commits';
 
 /** Extension-specific transport injected by the host panel (chrome.* or browser.*). */
 export type CallApi = <T>(method: string, ...args: unknown[]) => Promise<T>;
@@ -120,7 +121,7 @@ let isRecording = false;
 let events: TimelineEvent[] = [];
 let rankedComponents: ComponentRanking[] = [];
 let selectedEvent: TimelineEvent | null = null;
-let currentView: 'events' | 'ranked' | 'flamegraph' = 'events';
+let currentView: 'events' | 'ranked' | 'flamegraph' | 'commits' = 'events';
 let refreshInterval: number | null = null;
 let lastEventId = -1;
 
@@ -131,6 +132,11 @@ let axisMode: AxisMode = 'sequence';
 let timeScale: TimeScale | null = null;
 let timeScaleEventCount = -1;
 let timeScaleAxisMode: AxisMode | null = null;
+
+// Commits view state (commits derived client-side, see commits.ts)
+let commitsCache: Commit[] | null = null;
+let commitsCacheEventCount = -1;
+let selectedCommitIndex: number | null = null;
 
 // Skeleton tracking: rebuild swimlane rows only when the component set changes.
 let renderedSwimlaneKey = '';
@@ -225,6 +231,9 @@ function invalidateRenderCaches(): void {
     renderedSwimlaneKey = '';
     renderedListKey = '';
     timeScaleEventCount = -1;
+    commitsCache = null;
+    commitsCacheEventCount = -1;
+    selectedCommitIndex = null;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -284,6 +293,9 @@ function updateUI(): void {
             break;
         case 'flamegraph':
             renderFlamegraph();
+            break;
+        case 'commits':
+            renderCommitsView();
             break;
     }
 
@@ -692,6 +704,99 @@ function generateTimeAxis(scale: TimeScale, visibleStart: number, visibleRange: 
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// COMMITS VIEW (React-DevTools-style: one bar per burst of rendering)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getCommits(): Commit[] {
+    if (!commitsCache || commitsCacheEventCount !== events.length) {
+        commitsCache = deriveCommits(events);
+        commitsCacheEventCount = events.length;
+    }
+    return commitsCache;
+}
+
+/** Heat color for a commit relative to the slowest commit in the recording. */
+function commitColor(commit: Commit, maxMs: number): string {
+    const ratio = maxMs > 0 ? commit.totalRenderMs / maxMs : 0;
+    if (ratio > 0.66) return '#ef4444';
+    if (ratio > 0.33) return '#f59e0b';
+    return '#22c55e';
+}
+
+function renderCommitsView(): void {
+    const container = document.getElementById('timeline-content')!;
+    const commits = getCommits();
+
+    if (commits.length === 0) {
+        container.innerHTML = `
+            <div class="timeline-empty">
+                <div class="empty-icon">📊</div>
+                <div class="empty-title">No commits recorded</div>
+                <div class="empty-hint">Record some interactions — each burst of rendering becomes a commit</div>
+            </div>
+        `;
+        return;
+    }
+
+    if (selectedCommitIndex === null || selectedCommitIndex >= commits.length) {
+        selectedCommitIndex = commits.length - 1; // most recent by default
+    }
+
+    const maxMs = Math.max(...commits.map(c => c.totalRenderMs));
+
+    container.innerHTML = `
+        <div class="commits-container">
+            <div class="commit-chart" title="One bar per commit — click to inspect, ←/→ to navigate">
+                ${commits.map(c => {
+                    const heightPct = Math.max(maxMs > 0 ? (c.totalRenderMs / maxMs) * 100 : 0, 6);
+                    const isSelected = c.index === selectedCommitIndex;
+                    return `<div class="commit-bar ${isSelected ? 'selected' : ''}"
+                                 data-commit="${c.index}"
+                                 style="height: ${heightPct}%; background: ${commitColor(c, maxMs)}"
+                                 title="Commit ${c.index + 1}: ${c.renderCount} render${c.renderCount === 1 ? '' : 's'}, ${formatDuration(c.totalRenderMs)} at ${formatTime(c.startMs)}"></div>`;
+                }).join('')}
+            </div>
+            <div class="commit-hint">${commits.length} commit${commits.length === 1 ? '' : 's'} • click a bar or use ← → to navigate</div>
+            <div class="commit-detail" id="commit-detail">
+                ${renderCommitDetail(commits[selectedCommitIndex])}
+            </div>
+        </div>
+    `;
+}
+
+function renderCommitDetail(commit: Commit): string {
+    const maxComponentMs = Math.max(...commit.components.map(c => c.durationMs), 0.001);
+    return `
+        <div class="commit-detail-header">
+            <span class="commit-detail-title">Commit ${commit.index + 1}</span>
+            <span class="commit-detail-meta">
+                started ${formatTime(commit.startMs)} into recording •
+                ${commit.renderCount} render${commit.renderCount === 1 ? '' : 's'} •
+                ${formatDuration(commit.totalRenderMs)} total
+            </span>
+        </div>
+        ${commit.components.map(c => `
+            <div class="commit-component-row" data-event-id="${c.firstEventId}"
+                 title="Click to inspect this component's render event">
+                <span class="commit-component-name">${escapeHtml(c.componentName)}</span>
+                <div class="commit-component-bar-container">
+                    <div class="commit-component-bar" style="width: ${(c.durationMs / maxComponentMs) * 100}%"></div>
+                </div>
+                <span class="commit-component-duration">${formatDuration(c.durationMs)}</span>
+                ${c.renderCount > 1 ? `<span class="commit-component-count">×${c.renderCount}</span>` : '<span class="commit-component-count"></span>'}
+            </div>
+        `).join('')}
+    `;
+}
+
+function selectCommit(index: number): void {
+    const commits = getCommits();
+    if (commits.length === 0) return;
+    selectedCommitIndex = Math.min(Math.max(index, 0), commits.length - 1);
+    renderCommitsView();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // ZOOM & PAN (virtual-time space)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -937,10 +1042,17 @@ function initializeEventHandlers(): void {
 
         if (dragMoved) return; // A pan gesture just ended — not a click.
 
-        const eventEl = target.closest<HTMLElement>('.event-row, .swimlane-event');
+        const eventEl = target.closest<HTMLElement>('.event-row, .swimlane-event, .commit-component-row');
         if (eventEl) {
             e.stopPropagation();
             selectEventById(parseInt(eventEl.getAttribute('data-event-id')!, 10));
+            return;
+        }
+
+        const commitBar = target.closest<HTMLElement>('.commit-bar');
+        if (commitBar) {
+            e.stopPropagation();
+            selectCommit(parseInt(commitBar.getAttribute('data-commit')!, 10));
             return;
         }
 
@@ -1002,6 +1114,18 @@ function initializeEventHandlers(): void {
         // so a pan gesture doesn't select whatever ends up under the cursor.
         setTimeout(() => { dragMoved = false; }, 0);
     });
+
+    // ←/→ navigate commits while the commits view is visible (ignored while
+    // typing in an input/select so it can't fight the axis-mode dropdown etc).
+    document.addEventListener('keydown', (e) => {
+        if (currentView !== 'commits') return;
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+        if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+        e.preventDefault();
+        const current = selectedCommitIndex ?? getCommits().length - 1;
+        selectCommit(current + (e.key === 'ArrowRight' ? 1 : -1));
+    });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1039,6 +1163,7 @@ export function __resetForTests(): void {
     panOffset = 0;
     axisMode = 'sequence';
     timeScale = null;
+    selectedCommitIndex = null;
     invalidateRenderCaches();
     pointerDownX = null;
     dragMoved = false;

--- a/src/browser-extensions/src/shared/panel/panel.html
+++ b/src/browser-extensions/src/shared/panel/panel.html
@@ -102,6 +102,7 @@
                 <button class="timeline-view-tab active" data-view="events">Events</button>
                 <button class="timeline-view-tab" data-view="ranked">Ranked</button>
                 <button class="timeline-view-tab" data-view="flamegraph">Flamegraph</button>
+                <button class="timeline-view-tab" data-view="commits" title="One bar per burst of rendering — click a bar to see what rendered in that commit and for how long">Commits</button>
             </div>
             
             <!-- Timeline Main Content -->

--- a/src/browser-extensions/src/shared/panel/timeline-panel.css
+++ b/src/browser-extensions/src/shared/panel/timeline-panel.css
@@ -812,6 +812,132 @@
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════════
+   COMMITS VIEW (one bar per burst of rendering)
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+.commits-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 12px;
+    box-sizing: border-box;
+}
+
+.commit-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 110px;
+    padding: 8px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    overflow-x: auto;
+    flex-shrink: 0;
+}
+
+.commit-bar {
+    width: 14px;
+    min-width: 8px;
+    flex-shrink: 0;
+    border-radius: 2px 2px 0 0;
+    cursor: pointer;
+    opacity: 0.75;
+    transition: opacity 0.1s ease;
+}
+
+.commit-bar:hover {
+    opacity: 1;
+}
+
+.commit-bar.selected {
+    opacity: 1;
+    box-shadow: 0 0 0 2px var(--accent-color);
+}
+
+.commit-hint {
+    font-size: 10px;
+    color: var(--text-muted);
+    padding: 6px 2px;
+    flex-shrink: 0;
+}
+
+.commit-detail {
+    flex: 1;
+    overflow: auto;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 8px;
+}
+
+.commit-detail-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding-bottom: 8px;
+    margin-bottom: 6px;
+    border-bottom: 1px solid var(--border-color);
+    flex-wrap: wrap;
+}
+
+.commit-detail-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.commit-detail-meta {
+    font-size: 10px;
+    color: var(--text-muted);
+}
+
+.commit-component-row {
+    display: grid;
+    grid-template-columns: minmax(90px, 160px) 1fr 64px 32px;
+    align-items: center;
+    gap: 8px;
+    padding: 3px 4px;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 11px;
+}
+
+.commit-component-row:hover {
+    background: var(--bg-hover);
+}
+
+.commit-component-name {
+    color: var(--component-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.commit-component-bar-container {
+    height: 8px;
+    background: var(--bg-secondary);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.commit-component-bar {
+    height: 100%;
+    background: var(--accent-color);
+    border-radius: 2px;
+}
+
+.commit-component-duration {
+    text-align: right;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+.commit-component-count {
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
    RESPONSIVE ADJUSTMENTS
    ═══════════════════════════════════════════════════════════════════════════════ */
 

--- a/src/browser-extensions/tests/commits.test.ts
+++ b/src/browser-extensions/tests/commits.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { deriveCommits } from '../src/core/commits';
+import type { TimelineEvent } from '../src/core/types';
+
+function ev(overrides: Partial<TimelineEvent>): TimelineEvent {
+    return {
+        eventId: 0,
+        relativeTimestampMs: 0,
+        componentId: 1,
+        componentName: 'Counter',
+        eventType: 'BuildRenderTree',
+        durationMs: 2,
+        endRelativeTimestampMs: null,
+        parentEventId: null,
+        triggeringEventId: null,
+        triggerReason: 'Unknown',
+        triggerDetails: null,
+        isAsync: false,
+        isFirstRender: false,
+        wasSkipped: false,
+        isEnhanced: false,
+        batchId: null,
+        metadata: null,
+        ...overrides,
+    } as TimelineEvent;
+}
+
+describe('deriveCommits', () => {
+    it('clusters events separated by large gaps into distinct commits', () => {
+        const commits = deriveCommits([
+            ev({ eventId: 0, relativeTimestampMs: 0, durationMs: 2 }),
+            ev({ eventId: 1, relativeTimestampMs: 5, durationMs: 3 }),
+            ev({ eventId: 2, relativeTimestampMs: 5000, durationMs: 4 }),
+        ]);
+        expect(commits).toHaveLength(2);
+        expect(commits[0].renderCount).toBe(2);
+        expect(commits[0].totalRenderMs).toBe(5);
+        expect(commits[1].renderCount).toBe(1);
+        expect(commits[1].startMs).toBe(5000);
+        expect(commits.map(c => c.index)).toEqual([0, 1]);
+    });
+
+    it('keeps events within the gap threshold in one commit', () => {
+        // Chained events 40ms apart (< 50ms default gap) stay together.
+        const commits = deriveCommits([
+            ev({ eventId: 0, relativeTimestampMs: 0, durationMs: 1 }),
+            ev({ eventId: 1, relativeTimestampMs: 40, durationMs: 1 }),
+            ev({ eventId: 2, relativeTimestampMs: 80, durationMs: 1 }),
+        ]);
+        expect(commits).toHaveLength(1);
+        expect(commits[0].renderCount).toBe(3);
+    });
+
+    it('measures the gap from the cluster END, not its start', () => {
+        // A 100ms-long render followed 30ms after its end by another event:
+        // still one commit even though the starts are 130ms apart.
+        const commits = deriveCommits([
+            ev({ eventId: 0, relativeTimestampMs: 0, durationMs: 100 }),
+            ev({ eventId: 1, relativeTimestampMs: 130, durationMs: 2 }),
+        ]);
+        expect(commits).toHaveLength(1);
+    });
+
+    it('drops clusters containing no render work', () => {
+        const commits = deriveCommits([
+            ev({ eventId: 0, relativeTimestampMs: 0, durationMs: 2 }),
+            // Isolated lifecycle-only cluster: not a commit.
+            ev({ eventId: 1, relativeTimestampMs: 5000, eventType: 'StateHasChanged', durationMs: 0 }),
+        ]);
+        expect(commits).toHaveLength(1);
+    });
+
+    it('builds a per-component breakdown sorted slowest-first', () => {
+        const commits = deriveCommits([
+            ev({ eventId: 0, relativeTimestampMs: 0, componentId: 1, componentName: 'Fast', durationMs: 1 }),
+            ev({ eventId: 1, relativeTimestampMs: 2, componentId: 2, componentName: 'Slow', durationMs: 9 }),
+            ev({ eventId: 2, relativeTimestampMs: 4, componentId: 1, componentName: 'Fast', durationMs: 1 }),
+        ]);
+        expect(commits).toHaveLength(1);
+        const [slow, fast] = commits[0].components;
+        expect(slow).toMatchObject({ componentName: 'Slow', durationMs: 9, renderCount: 1 });
+        expect(fast).toMatchObject({ componentName: 'Fast', durationMs: 2, renderCount: 2, firstEventId: 0 });
+    });
+
+    it('handles unsorted input and empty input', () => {
+        expect(deriveCommits([])).toEqual([]);
+        const commits = deriveCommits([
+            ev({ eventId: 1, relativeTimestampMs: 5000, durationMs: 1 }),
+            ev({ eventId: 0, relativeTimestampMs: 0, durationMs: 1 }),
+        ]);
+        expect(commits).toHaveLength(2);
+        expect(commits[0].startMs).toBe(0);
+    });
+});

--- a/src/browser-extensions/tests/timeline-panel.test.ts
+++ b/src/browser-extensions/tests/timeline-panel.test.ts
@@ -201,6 +201,48 @@ describe('timeline panel', () => {
         expect(calls.filter(c => c === 'StartTimelineRecording')).toHaveLength(1);
     });
 
+    describe('commits view', () => {
+        // BURSTY_EVENTS has render work around 1-8ms and around 5000ms:
+        // two commits.
+
+        beforeEach(async () => {
+            initializeTimelinePanel(makeFakeApi(BURSTY_EVENTS).api);
+            await recordAndStop();
+            switchToView('commits');
+        });
+
+        it('renders one bar per commit and selects the latest by default', () => {
+            const bars = document.querySelectorAll('.commit-bar');
+            expect(bars).toHaveLength(2);
+            expect(bars[1].classList.contains('selected')).toBe(true);
+            // Detail shows the second burst's components.
+            const detail = document.getElementById('commit-detail')!;
+            expect(detail.textContent).toContain('Commit 2');
+            expect(detail.textContent).toContain('Counter');
+        });
+
+        it('clicking a bar shows that commit\'s component breakdown', () => {
+            click(document.querySelector('.commit-bar[data-commit="0"]')!);
+            const detail = document.getElementById('commit-detail')!;
+            expect(detail.textContent).toContain('Commit 1');
+            expect(detail.textContent).toContain('NavMenu');
+        });
+
+        it('navigates commits with arrow keys', () => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+            expect(document.querySelector('.commit-bar[data-commit="0"]')!.classList.contains('selected')).toBe(true);
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+            expect(document.querySelector('.commit-bar[data-commit="1"]')!.classList.contains('selected')).toBe(true);
+        });
+
+        it('clicking a component row opens that render event\'s details', () => {
+            click(document.querySelector('.commit-component-row')!);
+            const details = document.getElementById('timeline-details')!;
+            expect(details.textContent).not.toContain('Select an event to view details');
+            expect(details.textContent).toContain('Build Render Tree');
+        });
+    });
+
     describe('flamegraph axis modes', () => {
         function selectAxisMode(mode: string): void {
             const select = document.getElementById('axis-mode-select') as HTMLSelectElement;


### PR DESCRIPTION
React DevTools' signature profiler model for Blazor: a **Commits** tab in the Timeline showing one bar per burst of rendering — bar height & heat color = total render time. Click a bar (or ←/→) to see that commit's per-component breakdown; click a row to open the render event's details.

**Design note:** the package's render-batch recording (`RecordBatchStart`) has zero callers, so `BatchId` is always null — commits are therefore derived **client-side** by time-clustering (`core/commits.ts`, gap measured from cluster end). That makes this extension-only and compatible with published NuGet beta.7. When real BatchIds land package-side, `commits.ts` prefers them with clustering as fallback.

**Stacked on #61** (base = `tree-search-filters`) — merge #61 first; GitHub will retarget this to master automatically. 73 tests passing (10 new). Targeting extension **beta.6** together with #61.